### PR TITLE
TemplateError à priori réparée

### DIFF
--- a/app/views/groups/show.html.erb
+++ b/app/views/groups/show.html.erb
@@ -13,7 +13,7 @@
       <%= submit_tag "ok" %>
       <% end %>
 <% else %>
-  Enseignant TP:<%=  @group.lab_teacher.user.name %>
+  Enseignant TP:<%=  @group.lab_teacher.user.try(:name) %>
   <% end %>
 </p>
 
@@ -26,7 +26,7 @@
       <%= submit_tag "ok" %>
       <% end %>
 <% else %>
-  Enseignant TD:<%=  @group.theory_teacher.user.name %>
+  Enseignant TD:<%=  @group.theory_teacher.user.try(:name) %>
   <% end %>
 </p>
 


### PR DESCRIPTION
J'ai essayé de régler le problème du TemplateError lorsque l'on ajoute un enseignant (quelqu'il soit) à un groupe, le problème arrive souvent lorsqu'on ajoute le 2ème enseignant mais pas que.
Selon les cas, il parait que cela peut provenir d'un bug issu de Rails 2.2 (toujours présent dans le 2.3 ?).

La correction semble régler le problème et semble stable.
Elle doit valeur le coup d’œil même si je ne l'explique pas et qu'elle ne sera peut être pas retenue.